### PR TITLE
Limit google API results and break words in user notes

### DIFF
--- a/src/api/googleBooks.js
+++ b/src/api/googleBooks.js
@@ -9,6 +9,7 @@ function getBooks(query) {
             ...(import.meta.env.VITE_APP_GOOGLE_BOOKS_API_KEY && {
                 key: import.meta.env.VITE_APP_GOOGLE_BOOKS_API_KEY,
             }),
+            maxResults: 3,
         },
     });
 }

--- a/src/components/BookCard.vue
+++ b/src/components/BookCard.vue
@@ -81,7 +81,7 @@
                 class="mt-2 text-sm italic text-gray-400"
                 :class="{ 'md:text-lg': size === 'lg' }"
             >
-                <p>&ldquo;{{ book.user_note }}&rdquo;</p>
+                <p class="break-words">&ldquo;{{ book.user_note }}&rdquo;</p>
                 <p>&ndash;&ensp;{{ book.profiles.full_name }}</p>
             </div>
             <Collapse

--- a/src/components/BookInput.vue
+++ b/src/components/BookInput.vue
@@ -195,7 +195,7 @@ const submitBook = async (book) => {
 const searchBooks = _debounce(async (query) => {
     if (query) {
         const response = await getBooks(query);
-        results.value = response.data.items.slice(0, 3);
+        results.value = response.data.items;
     } else {
         results.value = null;
     }


### PR DESCRIPTION
Speed up search API results by trimming unused data in the request instead of client side.

Minor UI fix when user notes include long non-breaking strings like some URLs.  