### PR TITLE
[Bug] User note input iOS zoom

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -24,6 +24,10 @@
     .collapse-arrow .collapse-title:after {
         right: 0.25rem;
     }
+
+    .textarea {
+        @apply text-base;
+    }
 }
 
 .bounce-enter-active {


### PR DESCRIPTION
Addresses issue #37 

When iOS users click the user note input when submitting a new book, iOS zooms to fit the input to the screen. The user has to manually zoom back out to use the app.

Fix this by overriding DaisyUI default textarea styling to use a font-size of 16px instead of 14px. 

Why it defaults to 14px in the first place is something I will never understand.  